### PR TITLE
Ensured Elixir 1.2 compatibility

### DIFF
--- a/lib/zookeeper/recipe/election.ex
+++ b/lib/zookeeper/recipe/election.ex
@@ -78,14 +78,14 @@ defmodule Zookeeper.Election do
   def handle_call(:contenders, _from, %{client: zk, path: path}=state) do
     contenders = sorted_children(state)
       |> Enum.map(
-        fn node -> 
+        fn node ->
           case Zookeeper.Client.get(zk, "#{path}/#{node}") do
             {:ok, {data, _stat}} -> data
             {:error, :no_node} -> nil
           end
         end
       )
-      |> Enum.reject &is_nil(&1)
+      |> Enum.reject(&is_nil(&1))
     {:reply, contenders, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Zookeeper.Mixfile do
     [
       app: :zookeeper,
       version: "0.0.1",
-      elixir: ">= 1.0.0 and < 1.2.0",
+      elixir: ">= 1.0.0",
       deps: deps,
       package: package,
       description: "Zookeeper client for Elixir with common recipes."
@@ -21,7 +21,7 @@ defmodule Zookeeper.Mixfile do
   defp deps do
     [
       {:erlzk, github: "huaban/erlzk", ref: "a005aab956e88686d8d9e719cb3937ae91c98b68"},
-      {:uuid, "~> 0.1.5"},
+      {:uuid, "~> 1.1"},
     ]
   end
 
@@ -29,7 +29,7 @@ defmodule Zookeeper.Mixfile do
     [
       contributors: ["Stanislav Vishnevskiy"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/vishnevskiy/zookeeper-elixir"} 
+      links: %{"GitHub" => "https://github.com/vishnevskiy/zookeeper-elixir"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"erlzk": {:git, "https://github.com/huaban/erlzk.git", "a005aab956e88686d8d9e719cb3937ae91c98b68", [ref: "a005aab956e88686d8d9e719cb3937ae91c98b68"]},
-  "uuid": {:hex, :uuid, "0.1.5"}}
+  "uuid": {:hex, :uuid, "1.1.3"}}


### PR DESCRIPTION
This works just fine under elixir 1.2. Includes the following:
- Fixed compile warning due to pipes without parens
- Updated to latest UUID library, which was generating problems in 1.2

I'm not sure why the last PR was so strict with what versions of elixir it required, but this works just fine under 1.2. 

@vishnevskiy, great work.
