### PR TITLE
Fix typo in writelock recipe handle_cast impl

### DIFF
--- a/lib/zookeeper/recipe/writelock.ex
+++ b/lib/zookeeper/recipe/writelock.ex
@@ -53,7 +53,7 @@ defmodule Zookeeper.WriteLock do
     {:noreply, state}
   end
 
-  def handle_cast(:try_lock, _from, %{return_pid: return_pid}=state) do
+  def handle_cast(:try_lock, %{return_pid: return_pid}=state) do
     case try_lock(state) do
       {:reply, value, _state} -> GenServer.reply(return_pid, value)
       _ -> nil


### PR DESCRIPTION
This is an interesting bug; the tests catch it on my box, but only when run several times. The first test run passes, and then every subsequent run fails. 

Stacktrace output from a failing test run:

```
  1) test writelock (WriteLockTest)
     test/recipe/writelock_test.exs:18
     ** (EXIT from #PID<0.230.0>) an exception was raised:
         ** (UndefinedFunctionError) function Zookeeper.WriteLock.handle_cast/2 is undefined or private. Did you mean one of:

           * handle_cast/3

             (zookeeper) Zookeeper.WriteLock.handle_cast(:try_lock, %{fun: #Function<1.82202734/0 in WriteLockTest.spawn_contender/2>, node: "095558a7383847fc82ff4f723f64a36e__lock__0000000001", path: "/exunit-writelock", return_pid: {#PID<0.230.0>, #Reference<0.0.4.1487>}, zk: #PID<0.228.0>})
             (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
             (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
             (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```