### PR TITLE
Watch recipes accept a watcher pid; default to self

### DIFF
--- a/lib/zookeeper/recipe/children_watch.ex
+++ b/lib/zookeeper/recipe/children_watch.ex
@@ -16,15 +16,15 @@ defmodule Zookeeper.ChildrenWatch do
   @doc """
   Create a children watcher for a path.
   """
-  def start(client, path) do
-    GenServer.start(__MODULE__, {client, path, self()})
+  def start(client, path, watcher \\ self()) do
+    GenServer.start(__MODULE__, {client, path, watcher})
   end
 
   @doc """
   Create a children watcher for a path.
   """
-  def start_link(client, path) do
-    GenServer.start_link(__MODULE__, {client, path, self()})
+  def start_link(client, path, watcher \\ self()) do
+    GenServer.start_link(__MODULE__, {client, path, watcher})
   end
 
   @doc """

--- a/lib/zookeeper/recipe/data_watch.ex
+++ b/lib/zookeeper/recipe/data_watch.ex
@@ -19,15 +19,15 @@ defmodule Zookeeper.DataWatch do
   @doc """
   Create a data watcher for a path.
   """
-  def start(client, path) do
-    GenServer.start(__MODULE__, {client, path, self()})
+  def start(client, path, watcher \\ self()) do
+    GenServer.start(__MODULE__, {client, path, watcher})
   end
 
   @doc """
   Create a data watcher for a path.
   """
-  def start_link(client, path) do
-    GenServer.start_link(__MODULE__, {client, path, self()})
+  def start_link(client, path, watcher \\ self()) do
+    GenServer.start_link(__MODULE__, {client, path, watcher})
   end
 
   @doc """


### PR DESCRIPTION
This makes the data/child watch recipes a little more flexible. No change for
existing users.

I'm working on an app that sets a large number of watches: ideally I'd like those watch notifications to get sent to processes dedicated to the output of that specific watch, rather than having the ZK client manager process handle all of the messages and re-dispatch them. While I could have each of them grab the ZK client pid and create the watch themselves, I was hoping to keep them a bit distinct from ZK details. This is a super minor thing that's easy to cope with if you think it doesn't fit, so no worries either way.

Thanks for your consideration!